### PR TITLE
Retry on http exceptions

### DIFF
--- a/ambiata-cli.cabal
+++ b/ambiata-cli.cabal
@@ -44,6 +44,7 @@ library
                      , http-types                      == 0.8.*
                      , lens                            >= 4.8       && <= 4.10
                      , network-uri                     == 2.6.*
+                     , retry                           == 0.6.*
                      , old-locale                      == 1.0.*
                      , text                            == 1.2.1.*
                      , time                            == 1.4.*
@@ -145,7 +146,7 @@ test-suite test-io
                     , network                         == 2.6.*
                     , quickcheck-instances            == 0.3.*
                     , random                          == 1.1.*
-                    , retry                           == 0.6.*
+                    , retry
                     , scotty
                     , temporary
                     , text                            == 1.2.1.*

--- a/src/Ambiata/Cli/Credentials.hs
+++ b/src/Ambiata/Cli/Credentials.hs
@@ -49,7 +49,7 @@ obtainCredentials :: PermissionDirection -> AmbiataAPIKey -> AmbiataAPIEndpoint 
 obtainCredentials pd key' (AmbiataAPIEndpoint ep)  = do
   m <- liftIO $ newManager tlsManagerSettings
   req <- parseUrl $ T.unpack ep
-  res <- (liftIO . httpGo httpRetryPolicy m $ getTokenRequest pd req key') `catch` (\(e :: HttpException) -> left $ NetworkException e)
+  (res, _) <- (liftIO . httpGo httpRetryPolicy m $ getTokenRequest pd req key') `catch` (\(e :: HttpException) -> left $ NetworkException e)
   case responseStatus res of
     (Status 200 _) ->
       hoistEither . first (DecodeError . pack) . eitherDecode $ responseBody res

--- a/src/Ambiata/Cli/Credentials.hs
+++ b/src/Ambiata/Cli/Credentials.hs
@@ -49,7 +49,7 @@ obtainCredentials :: PermissionDirection -> AmbiataAPIKey -> AmbiataAPIEndpoint 
 obtainCredentials pd key' (AmbiataAPIEndpoint ep)  = do
   m <- liftIO $ newManager tlsManagerSettings
   req <- parseUrl $ T.unpack ep
-  res <- (liftIO . httpGo m $ getTokenRequest pd req key') `catch` (\(e :: HttpException) -> left $ NetworkException e)
+  res <- (liftIO . httpGo httpRetryPolicy m $ getTokenRequest pd req key') `catch` (\(e :: HttpException) -> left $ NetworkException e)
   case responseStatus res of
     (Status 200 _) ->
       hoistEither . first (DecodeError . pack) . eitherDecode $ responseBody res

--- a/src/Ambiata/Cli/Http.hs
+++ b/src/Ambiata/Cli/Http.hs
@@ -1,29 +1,59 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 module Ambiata.Cli.Http (
     httpGo
+  , httpRetryPolicy
   , encodePathSegmentsBS
   ) where
 
 import           Blaze.ByteString.Builder (toByteString)
+
+import           Control.Monad.Catch
+import           Control.Retry
 
 import           Data.ByteString
 import qualified Data.ByteString.Lazy as BSL
 import           Data.Text
 
 import           Network.HTTP.Client
+import           Network.HTTP.Types
 import           Network.HTTP.Types.URI as URI (encodePathSegments)
 
 import           P
 
 import           System.IO
 
+import           Twine.Snooze
 
-httpGo :: Manager -> Request -> IO (Response BSL.ByteString)
-httpGo mgr req =
+
+httpGo' :: Manager -> Request -> IO (Response BSL.ByteString)
+httpGo' mgr req =
   httpLbs req { checkStatus = checkStatusIgnore } mgr
   where
     -- A stupid default of http-client is to throw exceptions for non-200
     checkStatusIgnore _ _ _ = Nothing
+
+httpGo :: RetryPolicy -> Manager -> Request -> IO (Response BSL.ByteString)
+httpGo rp mgr req =
+    retrying rp (\_ -> pure . httpStatusRetry . responseStatus)
+  . recovering rp [const httpExceptionHandler]
+  $ httpGo' mgr req
+
+httpRetryPolicy :: RetryPolicy
+httpRetryPolicy =
+  capDelay (toMicroseconds $ seconds 60) $ limitRetries 5 <> exponentialBackoff (toMicroseconds $ milliseconds 100)
+
+-- | Return true for any 'HttpException'
+httpExceptionHandler :: Monad m => Handler m Bool
+httpExceptionHandler =
+  Handler $ \case
+    (_ :: HttpException) -> return True
+
+-- | Retry on anything that's an "error"
+httpStatusRetry :: Status -> Bool
+httpStatusRetry (Status s _) =
+  s >= 500
 
 -- | For setting 'queryString' on http-client "Request"
 encodePathSegmentsBS :: [Text] -> ByteString

--- a/test/Test/IO/Ambiata/Cli/Http.hs
+++ b/test/Test/IO/Ambiata/Cli/Http.hs
@@ -32,7 +32,7 @@ prop_httpGo =
   forAll (choose (100, 599)) $ \s -> testIO $
   withServer (get "/" . status $ Status s "") $ \req -> do
     mgr <- newManager defaultManagerSettings
-    resp <- httpGo mgr req
+    resp <- httpGo httpRetryPolicy mgr req
     pure $ responseStatus resp == Status s ""
 
 


### PR DESCRIPTION
/cc @nhibberd 

Should be doing exponential backoff as well? I wish `retrying` had a better return type, it's not trivial to add "reporting" to what it did or didn't retry. :(