### PR TITLE
Locks clock to 0.5.x

### DIFF
--- a/ambiata-cli.cabal
+++ b/ambiata-cli.cabal
@@ -32,6 +32,7 @@ library
                      , blaze-builder                   == 0.4.*
                      , bytestring                      == 0.10.*
                      , cryptohash                      == 0.11.*
+                     , clock                           == 0.5.*
                      , data-default                    == 0.5.*
                      , directory                       == 1.2.*
                      , either                          == 4.3.*


### PR DESCRIPTION
0.6 is broken w/ 7.8.4 + CentOS 6 (see https://github.com/corsis/clock/issues/35).

(The `clock` dependency is brought in via `turtle`.)