### PR TITLE
Revert "Locking down psqueues"

### DIFF
--- a/ambiata-cli.cabal
+++ b/ambiata-cli.cabal
@@ -56,8 +56,6 @@ library
                      , time                            == 1.4.*
                      , transformers                    >= 0.3        && < 0.5
                      , unix                            == 2.7.*
-                     -- Lock down psqueues due to incompatibility
-                     , psqueues                        == 0.2.0.3
 
 
 


### PR DESCRIPTION
This reverts commit 10fd9209daf4246a7d0b382531a01ca2c189a37b.

psqueues now at 0.2.2.0, which should run true.