### PR TITLE
Fix env parsing tests

### DIFF
--- a/ambiata-cli.cabal
+++ b/ambiata-cli.cabal
@@ -195,6 +195,7 @@ test-suite test-io
                     , containers                      == 0.5.*
                     , data-default                    == 0.5.*
                     , directory
+                    , envparse                        == 0.2.1
                     , filepath
                     , http-client                     == 0.4.18.*
                     , http-types                      == 0.8.*

--- a/src/Ambiata/Cli/Env.hs
+++ b/src/Ambiata/Cli/Env.hs
@@ -8,6 +8,7 @@ module Ambiata.Cli.Env (
   , uploadEnv'
   , downloadEnv
   , downloadEnv'
+  , common
   ) where
 
 import           Ambiata.Cli.Data

--- a/test/test-io.hs
+++ b/test/test-io.hs
@@ -3,6 +3,7 @@ import           Disorder.Core.Main
 
 import qualified Test.IO.Ambiata.Cli.Api.Upload
 import qualified Test.IO.Ambiata.Cli.Downloads
+import qualified Test.IO.Ambiata.Cli.Env
 import qualified Test.IO.Ambiata.Cli.Http
 import qualified Test.IO.Ambiata.Cli.Incoming
 import qualified Test.IO.Ambiata.Cli.Processing
@@ -12,9 +13,10 @@ main :: IO ()
 main =
   disorderMain [
       Test.IO.Ambiata.Cli.Api.Upload.tests
+    , Test.IO.Ambiata.Cli.Downloads.tests
+    , Test.IO.Ambiata.Cli.Env.tests
+    , Test.IO.Ambiata.Cli.Http.tests
     , Test.IO.Ambiata.Cli.Incoming.tests
     , Test.IO.Ambiata.Cli.Processing.tests
-    , Test.IO.Ambiata.Cli.Downloads.tests
-    , Test.IO.Ambiata.Cli.Http.tests
     , Test.IO.Ambiata.Cli.Standalone.tests
     ]


### PR DESCRIPTION
Tests weren't getting built/run. This patch runs them and updates them so they build.

They need a bit more love to be comprehensive; I'm fixing them up in the next PR along with parsing TSRP keys.

! @charleso @tmcgilchrist 