### PR TITLE
Add tightlist macro to fix doc build with recent pandocs

### DIFF
--- a/doc/templates/pdf.tex
+++ b/doc/templates/pdf.tex
@@ -142,6 +142,10 @@ $endif$
   \fancyhead[L]{\includegraphics[height=2cm,width=2cm]{assets/ambiata.png}}
 }
 
+% Current pandocs expect this to be defined in the latex template.
+\providecommand{\tightlist}{%
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+
 $for(header-includes)$
 $header-includes$
 $endfor$


### PR DESCRIPTION
Ancient pandoc is fine (e.g., centos 6), but recent versions (e.g., arch linux) require the `tightlist` macro in the latex template.

```
∃ pandoc --version
pandoc 1.17.2
Compiled with texmath 0.8.6.5, highlighting-kate 0.6.3.
Syntax highlighting is supported for the following languages:
    abc, actionscript, ada, agda, apache, asn1, asp, awk, bash, bibtex, boo, c,
    changelog, clojure, cmake, coffee, coldfusion, commonlisp, cpp, cs, css,
    curry, d, diff, djangotemplate, dockerfile, dot, doxygen, doxygenlua, dtd,
    eiffel, elixir, email, erlang, fasm, fortran, fsharp, gcc, glsl,
    gnuassembler, go, hamlet, haskell, haxe, html, idris, ini, isocpp, java,
    javadoc, javascript, json, jsp, julia, kotlin, latex, lex, lilypond,
    literatecurry, literatehaskell, llvm, lua, m4, makefile, mandoc, markdown,
    mathematica, matlab, maxima, mediawiki, metafont, mips, modelines, modula2,
    modula3, monobasic, nasm, noweb, objectivec, objectivecpp, ocaml, octave,
    opencl, pascal, perl, php, pike, postscript, prolog, pure, python, r,
    relaxng, relaxngcompact, rest, rhtml, roff, ruby, rust, scala, scheme, sci,
    sed, sgml, sql, sqlmysql, sqlpostgresql, tcl, tcsh, texinfo, verilog, vhdl,
    xml, xorg, xslt, xul, yacc, yaml, zsh
Default user data directory: /home/sio/.pandoc
Copyright (C) 2006-2016 John MacFarlane
Web:  http://pandoc.org
This is free software; see the source for copying conditions.
There is no warranty, not even for merchantability or fitness
for a particular purpose.
∃ make
pandoc -V geometry:margin=2cm --template=templates/pdf.tex setup.md -o setup.pdf
! Undefined control sequence.
l.108 \tightlist

pandoc: Error producing PDF
make: *** [Makefile:9: setup.pdf] Error 43
```

! @charleso 