### PR TITLE
Update doc publish scripts

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -1,5 +1,8 @@
 #!/bin/sh -exu
 
+: ${AMBIATA_DOC_MASTER:="s3://ambiata-dispensary-v2/doc/master"}
+
 $(dirname $0)/ci.common
 $(dirname $0)/publish-docs
+$(dirname $0)/publish-docs-dispensary ${AMBIATA_DOC_MASTER}
 $(dirname $0)/publish ${AMBIATA_DOWNLOAD}

--- a/bin/ci
+++ b/bin/ci
@@ -4,5 +4,5 @@
 
 $(dirname $0)/ci.common
 $(dirname $0)/publish-docs
-$(dirname $0)/publish-docs-dispensary ${AMBIATA_DOC_MASTER}
+$(dirname $0)/publish-docs-dispensary ${AMBIATA_DOC_MASTER} "http://doc.engineering.ambiata.com/master"
 $(dirname $0)/publish ${AMBIATA_DOWNLOAD}

--- a/bin/ci.branches
+++ b/bin/ci.branches
@@ -1,4 +1,7 @@
 #!/bin/sh -exu
 
+: ${AMBIATA_DOC_BRANCHES:="s3://ambiata-dispensary-v2/doc/branches"}
+
 $(dirname $0)/ci.common
+$(dirname $0)/publish-docs-dispensary ${AMBIATA_DOC_BRANCHES}
 $(dirname $0)/publish ${AMBIATA_ARTEFACTS_BRANCHES}

--- a/bin/ci.branches
+++ b/bin/ci.branches
@@ -3,5 +3,5 @@
 : ${AMBIATA_DOC_BRANCHES:="s3://ambiata-dispensary-v2/doc/branches"}
 
 $(dirname $0)/ci.common
-$(dirname $0)/publish-docs-dispensary ${AMBIATA_DOC_BRANCHES}
+$(dirname $0)/publish-docs-dispensary ${AMBIATA_DOC_BRANCHES} "http://doc.engineering.ambiata.com/branches"
 $(dirname $0)/publish ${AMBIATA_ARTEFACTS_BRANCHES}

--- a/bin/publish-docs-dispensary
+++ b/bin/publish-docs-dispensary
@@ -1,14 +1,19 @@
 #!/bin/sh -exu
 
 PROJECT="ambiata-cli"
+GIT_COMMIT=$(git rev-parse HEAD)
 
 doc_version=$(cat gen/version.txt)
 destination="$1"
+doc_root="$2"
 
 # Ensure the build is up to date.
 cd doc && make clean && make ; cd ..
 
 find doc \
      -maxdepth 1 \
-     -name \*.pdf \
-     -exec aws s3 --region=ap-southeast-2 cp --sse {} ${destination}/${PROJECT}/${doc_version}/{} \;
+     -name \*.pdf | while read F; do
+    aws s3 --region=ap-southeast-2 cp --sse ${F} ${destination}/${PROJECT}/${doc_version}/${F}
+    doc_url="${doc_root}/ambiata-cli/${doc_version}/${F}"
+    spoke -r "ambiata-cli" --commit "$GIT_COMMIT" --state "success" --context "doc-$F" -d "Documentation build: $F" -t "$doc_url"
+done

--- a/bin/publish-docs-dispensary
+++ b/bin/publish-docs-dispensary
@@ -1,0 +1,14 @@
+#!/bin/sh -exu
+
+PROJECT="ambiata-cli"
+
+doc_version=$(cat gen/version.txt)
+destination="$1"
+
+# Ensure the build is up to date.
+cd doc && make clean && make ; cd ..
+
+find doc \
+     -maxdepth 1 \
+     -name \*.pdf \
+     -exec aws s3 --region=ap-southeast-2 cp --sse {} ${destination}/${PROJECT}/${doc_version}/{} \;


### PR DESCRIPTION
Add branches, and publish to new location (dispensary-v2). Leave old
publish script until I know whether anything's relying on docs being
at the old location or not.

Lack of gewgaw status trigger is deliberate.

! @charleso 